### PR TITLE
Fix TechStart-Pro link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 # TechStart Pro - README Mejorado
-- **Link de la pagina TechStart-Pro**: [](https://techstart-pro.infinityfreeapp.com/)
+- **Link de la pagina TechStart-Pro**: [Pagina](https://techstart-pro.infinityfreeapp.com/)
 ## 🚀 TechStart Pro
 
 Una plataforma web completa de servicios tecnológicos desarrollada como proyecto académico para la Universidad Tecnológica de Aguascalientes. TechStart Pro combina una interfaz pública para mostrar servicios tecnológicos con un sistema administrativo robusto para la gestión de contenido.


### PR DESCRIPTION
Se actualizó el enlace del proyecto en el README para que se muestre como 'Pagina' en lugar de una etiqueta vacía para mayor claridad.